### PR TITLE
fix compatible problem

### DIFF
--- a/src/MySQLHandler/MySQLHandler.php
+++ b/src/MySQLHandler/MySQLHandler.php
@@ -161,7 +161,7 @@ class MySQLHandler extends AbstractProcessingHandler
      * @param  $record[]
      * @return void
      */
-    protected function write(array $record)
+    protected function write(array $record): void
     {
         if (!$this->initialized) {
             $this->initialize();


### PR DESCRIPTION
fix 
Declaration of MySQLHandler\MySQLHandler::write(array $record) must be compatible with Monolog\Handler\AbstractProcessingHandler::write(array $record): void